### PR TITLE
If string with id in meta cover exist, but...

### DIFF
--- a/epubmetadataeditor/Form1.vb
+++ b/epubmetadataeditor/Form1.vb
@@ -1216,7 +1216,9 @@ skipsecondcreator:
                         If startpos <> 0 Then
                             hreftype = "id=" + Chr(34) + coverid + Chr(34)
                             coverfilepos = InStr(startpos, metadatafile, hreftype)
-                            GoTo foundcoverid
+                            If coverfilepos > 0 Then
+                                GoTo foundcoverid
+                            End If                                                                                                
                         Else
                             coverfilepos = 0
                         End If


### PR DESCRIPTION
... this id not exist in manifest then of course `coverfilepos = 0` and we should not go to `foundcoverid`.

For most files with a valid cover id in the meta, this change should not matter.

The metadata will still remain `<meta name="cover" content="non_existent_id" />` with non-existent id, but there is a better chance of detecting the correct cover.

It's a temporary idea.

I know that a better solution would be to replace an incorrect entry in the metadata with the correct cover id.

Please test attached sample file with 1.7 version before and after patch.

[John Smith - Sample File for 1.7.epub.zip](https://github.com/benchen71/epub-metadata-editor/files/3287149/John.Smith.-.Sample.File.for.1.7.epub.zip)